### PR TITLE
Fix typos in Unkown CPU header file

### DIFF
--- a/TFT_ST7735.h
+++ b/TFT_ST7735.h
@@ -587,8 +587,8 @@ class TFT_ST7735 : public Print {
 	
 		void spiwrite16(uint16_t c)
 		__attribute__((always_inline)) {
-			SPI.transfer(d >> 8);
-			SPI.transfer(d);
+			SPI.transfer(c >> 8);
+			SPI.transfer(c);
 		}
 		
 		
@@ -604,7 +604,7 @@ class TFT_ST7735 : public Print {
 		__attribute__((always_inline)) {
 			if (!_dcState){
 				digitalWrite(_rs,HIGH);
-				__dcState = 1;
+				_dcState = 1;
 			}
 		}
 		


### PR DESCRIPTION
Fix typos in Unkown CPU header file.

Error:
```
In file included from src\main.cpp:9:
.pio\libdeps\nodemcuv2\TFT_ST7735/TFT_ST7735.h: In member function 'void TFT_ST7735::spiwrite16(uint16_t)':
.pio\libdeps\nodemcuv2\TFT_ST7735/TFT_ST7735.h:590:17: error: 'd' was not declared in this scope
  590 |    SPI.transfer(d >> 8);
      |                 ^
.pio\libdeps\nodemcuv2\TFT_ST7735/TFT_ST7735.h: In member function 'void TFT_ST7735::enableDataStream()':
.pio\libdeps\nodemcuv2\TFT_ST7735/TFT_ST7735.h:607:5: error: '__dcState' was not declared in this scope; did you mean '_dcState'?
  607 |     __dcState = 1;
      |     ^~~~~~~~~
      |     _dcState
In file included from .pio\libdeps\nodemcuv2\TFT_ST7735\TFT_ST7735.cpp:1:
.pio\libdeps\nodemcuv2\TFT_ST7735\TFT_ST7735.h: In member function 'void TFT_ST7735::spiwrite16(uint16_t)':
.pio\libdeps\nodemcuv2\TFT_ST7735\TFT_ST7735.h:590:17: error: 'd' was not declared in this scope
  590 |    SPI.transfer(d >> 8);
      |                 ^
.pio\libdeps\nodemcuv2\TFT_ST7735\TFT_ST7735.h: In member function 'void TFT_ST7735::enableDataStream()':
.pio\libdeps\nodemcuv2\TFT_ST7735\TFT_ST7735.h:607:5: error: '__dcState' was not declared in this scope; did you mean '_dcState'?
  607 |     __dcState = 1;
      |     ^~~~~~~~~
      |     _dcState
*** [.pio\build\nodemcuv2\src\main.cpp.o] Error 1
*** [.pio\build\nodemcuv2\lib4ba\TFT_ST7735\TFT_ST7735.cpp.o] Error 1```